### PR TITLE
Run 'brew' via 'sudo' to force a clean environment

### DIFF
--- a/providers/cask.rb
+++ b/providers/cask.rb
@@ -15,8 +15,8 @@ action :cask do
   unless @cask.casked
     execute "installing cask #{new_resource.name}" do
       user node['current_user']
-      command "/usr/local/bin/brew cask install --appdir=/Applications #{new_resource.name}"
-      not_if "/usr/local/bin/brew brew list | grep #{new_resource.name}"
+      command "sudo -u #{node['current_user']} /usr/local/bin/brew cask install --appdir=/Applications #{new_resource.name}"
+      not_if "sudo -u #{node['current_user']} /usr/local/bin/brew cask list | grep #{new_resource.name}"
     end
     new_resource.updated_by_last_action(true)
   end
@@ -26,8 +26,8 @@ action :uncask do
   if @cask.casked
     execute "uninstalling cask #{new_resource.name}" do
       user node['current_user']
-      command "/usr/local/bin/brew cask uninstall #{new_resource.name}"
-      only_if "/usr/local/bin/brew cask list | grep #{new_resource.name}"
+      command "sudo -u #{node['current_user']} /usr/local/bin/brew cask uninstall #{new_resource.name}"
+      only_if "sudo -u #{node['current_user']} /usr/local/bin/brew cask list | grep #{new_resource.name}"
     end
     new_resource.updated_by_last_action(true)
   end

--- a/providers/tap.rb
+++ b/providers/tap.rb
@@ -35,7 +35,7 @@ action :tap do
   unless @tap.tapped
     execute "tapping #{new_resource.name}" do
       user node['current_user']
-      command "/usr/local/bin/brew tap #{new_resource.name}"
+      command "sudo -u #{node['current_user']} /usr/local/bin/brew tap #{new_resource.name}"
     end
     new_resource.updated_by_last_action(true)
   end
@@ -45,7 +45,7 @@ action :untap do
   if @tap.tapped
     execute "untapping #{new_resource.name}" do
       user node['current_user']
-      command "/usr/local/bin/brew untap #{new_resource.name}"
+      command "sudo -u #{node['current_user']} /usr/local/bin/brew untap #{new_resource.name}"
     end
     new_resource.updated_by_last_action(true)
   end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -32,6 +32,7 @@ remote_file homebrew_go do
 end
 
 execute homebrew_go do
+  command "sudo -u #{node['current_user']} #{homebrew_go}"
   user node['current_user']
   not_if { ::File.exist? '/usr/local/bin/brew' }
 end
@@ -55,7 +56,7 @@ end
 
 execute 'update homebrew from github' do
   user node['current_user']
-  command '/usr/local/bin/brew update || true'
+  command "sudo -u #{node['current_user']} /usr/local/bin/brew update || true"
 end
 
 node['homebrewalt']['cask_apps'].each do |app|


### PR DESCRIPTION
If the user runs Chef via Bundler, as in the older Kitchenplan, it will execute in a modified environment, which forces Ruby subproceses to look for gemsonly in Bundler-controlled locations. This makes running 'brew' fail because it is shebang-ed to run with Ruby 1.8, while the gems were installed by the system Ruby (2.0 on Mavericks). By running 'brew' with a 'sudo -u', we'll get a clean environment and let Ruby 1.8 run without any interference from Bundler.
