### PR TITLE
Fix check for installed packages which always errors when upgrade is not required.

### DIFF
--- a/libraries/homebrew_package.rb
+++ b/libraries/homebrew_package.rb
@@ -44,7 +44,7 @@ class Chef
         end
 
         def upgrade_package(name, version)
-          unless `brew outdated | grep #{name}`
+          if shell_out!("brew outdated | grep #{name}", :returns => [0,1]).exitstatus.zero?
             brew('upgrade', name)
           end
         end


### PR DESCRIPTION
Appears to fix chef crash when `brew outdated | grep blah` exits with status 1 (which it would do any time a package is not outdated.)

Testing this is a little tricky as I'm not sure how to get homebrew to downgrade a package in a way such that it then realizes it is outdated.
