### PR TITLE
Search for exact name in installed cask list

### DIFF
--- a/providers/cask.rb
+++ b/providers/cask.rb
@@ -16,7 +16,7 @@ action :cask do
     execute "installing cask #{new_resource.name}" do
       user node['current_user']
       command "sudo -u #{node['current_user']} /usr/local/bin/brew cask install --appdir=/Applications #{new_resource.name}"
-      not_if "sudo -u #{node['current_user']} /usr/local/bin/brew cask list | grep #{new_resource.name}"
+      not_if "sudo -u #{node['current_user']} /usr/local/bin/brew cask list | grep '^#{new_resource.name}$'"
     end
     new_resource.updated_by_last_action(true)
   end
@@ -27,7 +27,7 @@ action :uncask do
     execute "uninstalling cask #{new_resource.name}" do
       user node['current_user']
       command "sudo -u #{node['current_user']} /usr/local/bin/brew cask uninstall #{new_resource.name}"
-      only_if "sudo -u #{node['current_user']} /usr/local/bin/brew cask list | grep #{new_resource.name}"
+      only_if "sudo -u #{node['current_user']} /usr/local/bin/brew cask list | grep '^#{new_resource.name}$'"
     end
     new_resource.updated_by_last_action(true)
   end


### PR DESCRIPTION
Casks are installed/uninstalled if they are present in the output of `brew cask list`, but this check is done with grep using the cask's name as a pattern. This will give false positives if a cask's name is a subset of another name, such as, for instance, "r". Instead, the search should be on the exact name, anchored with `^` and `$` to avoid substring matching.
