### PR TITLE
Fix cask tap

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -42,7 +42,7 @@ package 'git' do
   not_if 'which git'
 end
 
-homebrewalt_tap 'phinze/cask'
+homebrewalt_tap 'caskroom/cask'
 homebrewalt_tap 'caskroom/versions'
 homebrewalt_tap 'caskroom/fonts'
 homebrewalt_tap 'homebrew/dupes'


### PR DESCRIPTION
The tap currently taps the old location. Homebrew-cask has been moved into the caskroom organization.
