### PR TITLE
changed home-brew installer url

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -27,7 +27,7 @@ end
 homebrew_go = "#{Chef::Config[:file_cache_path]}/homebrew_go"
 
 remote_file homebrew_go do
-  source 'https://raw.github.com/Homebrew/homebrew/go/install'
+  source 'https://raw.githubusercontent.com/Homebrew/install/master/install'
   owner node['current_user']
   mode 00777
 end


### PR DESCRIPTION
- updated home-brew installer to the correct url. 
- When using homebrewalt received this message on install of homebrew
  #!/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby

puts <<-EOS
Whoops, the Homebrew installer has moved! Please instead run:

ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"

Also, please ask wherever you got this link from to update it to the above.
Thanks!
EOS
