### PR TITLE
NOT A FIX - workarounds to get past #16

### DIFF
--- a/libraries/homebrew_package.rb
+++ b/libraries/homebrew_package.rb
@@ -69,7 +69,7 @@ class Chef
         end
 
         def candidate_version
-          get_version_from_command("brew info #{@new_resource.package_name} | awk '/^#{@new_resource.package_name} / { print $2 }'")
+          get_version_from_command("brew info #{@new_resource.package_name} | awk '/^#{@new_resource.package_name}: / { print $3 }'")
         end
 
         def get_version_from_command(command)

--- a/libraries/homebrew_package.rb
+++ b/libraries/homebrew_package.rb
@@ -65,11 +65,12 @@ class Chef
         end
 
         def current_installed_version
-          get_version_from_command("brew list --versions | awk '/^#{@new_resource.package_name} / { print $2 }'")
+          #awk is unfriendly with /'s inside //, so use grep.
+          get_version_from_command("(brew list --versions | grep '^#{@new_resource.package_name} ' | awk '{ print $2 }'")
         end
 
         def candidate_version
-          get_version_from_command("brew info #{@new_resource.package_name} | awk '/^#{@new_resource.package_name}: / { print $3 }'")
+          get_version_from_command("brew info #{@new_resource.package_name} grep '^#{@new_resource.package_name}: ' | awk '{ print $3 }'")
         end
 
         def get_version_from_command(command)

--- a/libraries/homebrew_package.rb
+++ b/libraries/homebrew_package.rb
@@ -65,30 +65,16 @@ class Chef
         end
 
         def current_installed_version
-          pkg = get_version_from_formula
-          versions = pkg.to_hash['installed'].map {|v| v['version']}
-          versions.join(" ") unless versions.empty?
+          get_version_from_command("brew list --versions | awk '/^#{@new_resource.package_name} / { print $2 }'")
         end
 
         def candidate_version
-          pkg = get_version_from_formula
-          pkg.stable.version.to_s || pkg.version.to_s
+          get_version_from_command("brew info #{@new_resource.package_name} | awk '/^#{@new_resource.package_name} / { print $2 }'")
         end
 
         def get_version_from_command(command)
           version = get_response_from_command(command).chomp
           version.empty? ? nil : version
-        end
-
-        def get_version_from_formula
-          brew_cmd = shell_out!("sudo -u #{node['current_user']} brew --prefix")
-          libpath = ::File.join(brew_cmd.stdout.chomp, "Library", "Homebrew")
-          $:.unshift(libpath)
-
-          require 'global'
-          require 'cmd/info'
-
-          Formula.factory new_resource.package_name
         end
 
         def get_response_from_command(command)

--- a/libraries/homebrew_package.rb
+++ b/libraries/homebrew_package.rb
@@ -65,12 +65,11 @@ class Chef
         end
 
         def current_installed_version
-          #awk is unfriendly with /'s inside //, so use grep.
-          get_version_from_command("(brew list --versions | grep '^#{@new_resource.package_name} ' | awk '{ print $2 }'")
+          get_version_from_command("brew list --versions | awk '/^#{@new_resource.package_name} / { print $2 }'")
         end
 
         def candidate_version
-          get_version_from_command("brew info #{@new_resource.package_name} grep '^#{@new_resource.package_name}: ' | awk '{ print $3 }'")
+          get_version_from_command("brew info #{@new_resource.package_name} | awk '/^#{@new_resource.package_name}: / { print $3 }'")
         end
 
         def get_version_from_command(command)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -73,10 +73,6 @@ directory "/opt/homebrew-cask/Caskroom" do
     recursive true
 end
 
-package "brew-cask" do
-  options "--HEAD"
-end
-
 execute 'update homebrew from github' do
   user node['current_user']
   command "sudo -u #{node['current_user']} /usr/local/bin/brew update || true"


### PR DESCRIPTION
switches back to using cmd instead of formula for to determinte brew package versions - since the formula no longer works with current brew.

removed brew-cask, since that package appears to be built in now.

NOT a fix though - dupes do not work.    package{} installing a dupe will fail (ie rsync, nano) - and info and --list now use full homebrew/dupes/name labels which breaks the cmdline checking for version details.   more flexible checking....failed unreasonably and I ran out of time.

Probably time for homebrewalt  to review merging in more of the upstream changes in homebrew...or even rebasing and applying the feature changes over again.   Brew moved a LOT.

brew, otoh, really needs some plumbing vs porcelain split since it very much doesn't want it's ruby to be consumed directly anymore but it's cmdline interfaces keep changing.....

anyway.  
